### PR TITLE
chore(ci): use probablyup/wait-for-netlify-action@3.2.0

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,10 +16,10 @@ jobs:
     outputs:
       url: ${{ steps.netlify.outputs.url }}
     steps:
-      - uses: kamranayub/wait-for-netlify-action@v2.0.3
+      - uses: probablyup/wait-for-netlify-action@3.2.0
         id: netlify
         with:
-          site_name: "carved-rock-order-tracker-pwa"
+          site_id: "844b606a-25da-425c-9eb4-f2f362f9a9bc"
           max_timeout: 300
         env:
           NETLIFY_TOKEN: ${{secrets.NETLIFY_TOKEN}}


### PR DESCRIPTION
## Changes

- Switch to https://github.com/marketplace/actions/wait-for-netlify-deployment

## Context

It looks like this fork of my fork fixes some issues related to timeout and optimizes some of the API requests to use the site ID, instead of having to look up the ID from the site name (this is also resilient to name changes since the API ID doesn't change). See https://github.com/probablyup/wait-for-netlify-action/issues/1#issue-777401502 for details.